### PR TITLE
Added missing xui env variable SERVICES_DOCUMENTS_API_V2

### DIFF
--- a/compose/xui.yml
+++ b/compose/xui.yml
@@ -12,6 +12,7 @@ services:
       SERVICES_CCD_COMPONENT_API: http://ccd-api-gateway:3453
       SERVICES_CCD_DATA_STORE_API: http://ccd-data-store-api:4452
       SERVICES_DOCUMENTS_API: http://dm-store:8080
+      SERVICES_DOCUMENTS_API_V2: http://ccd-case-document-am-api:4455
       SERVICES_S2S: http://service-auth-provider-api:8080
       SERVICES_IDAM_LOGIN_URL: "${IDAM_STUB_LOCALHOST:-http://localhost:3501}"
       SERVICES_IDAM_API_URL: "${IDAM_STUB_SERVICE_NAME:-http://idam-api:5000}"


### PR DESCRIPTION
XUI now requires a SERVICES_DOCUMENTS_API_V2 variable to be set to the secure dock store api to enable uploading of document during create claim process.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
