### PR TITLE
civil-4535-add-senior-tribunal-caseworker-role

### DIFF
--- a/bin/am-role-assignments.json
+++ b/bin/am-role-assignments.json
@@ -254,5 +254,21 @@
       }
     ],
     "overrideAll": true
+  },
+  {
+    "email": "senior-tribunal-caseworker-01@example.com",
+    "roleAssignments": [
+      {
+        "roleType": "ORGANISATION",
+        "roleName": "senior-tribunal-caseworker",
+        "grantType": "STANDARD",
+        "roleCategory": "LEGAL_OPERATIONS",
+        "classification": "PUBLIC",
+        "readOnly": false,
+        "attributes": { "caseType": "CIVIL", "jurisdiction": "CIVIL" },
+        "authorisations": []
+      }
+    ],
+    "overrideAll": true
   }
 ]

--- a/bin/users.json
+++ b/bin/users.json
@@ -25,6 +25,7 @@
   {"email": "jane.smith@gmail.com", "roles": "citizen", "lastName": "Smith"},
   {"email": "tribunal-caseworker-01@example.com", "roles": "caseworker,caseworker-civil", "lastName": "tribunal-caseworker"},
   {"email": "hearing-centre-admin-01@example.com", "roles": "caseworker,caseworker-civil,caseworker-civil-admin", "lastName": "Admin"},
-  {"email": "hmcts-staff-09@example.com", "roles": "caseworker,caseworker-civil", "lastName": "standard"}
+  {"email": "hmcts-staff-09@example.com", "roles": "caseworker,caseworker-civil", "lastName": "standard"},
+  {"email": "senior-tribunal-caseworker-01@example.com", "roles": "caseworker,caseworker-civil", "lastName": "senior-tribunal-caseworker"}
 ]
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-4535

### Change description ###

Due to the configuration around specific and challenged access, we need to add an additional access management role to the CCD configuration. The role that needs to be added is:

senior-tribunal-caseworker

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
