### PR TITLE
CIV-0000 caseworker-wa-task-configuration back into add-roles script

### DIFF
--- a/bin/add-roles.sh
+++ b/bin/add-roles.sh
@@ -28,7 +28,7 @@ do
 done
 
 accessprofiles=("judge-profile" "basic-access" "ga-basic-access" "legal-adviser" "GS_profile" "caseworker-ras-validation" "full-access" "admin-access"
-"civil-administrator-basic" "civil-administrator-standard" "hearing-schedule-access" "APP-SOL-UNSPEC-PROFILE" "APP-SOL-SPEC-PROFILE" "RES-SOL-ONE-UNSPEC-PROFILE"
+"civil-administrator-basic" "civil-administrator-standard" "caseworker-wa-task-configuration" "hearing-schedule-access" "APP-SOL-UNSPEC-PROFILE" "APP-SOL-SPEC-PROFILE" "RES-SOL-ONE-UNSPEC-PROFILE"
 "RES-SOL-ONE-SPEC-PROFILE" "RES-SOL-TWO-UNSPEC-PROFILE" "RES-SOL-TWO-SPEC-PROFILE" "payment-access" "caseflags-admin" "caseflags-viewer" "hearing-manager" "hearing-viewer")
 
 for accessprofile in "${accessprofiles[@]}"


### PR DESCRIPTION
Added caseworker-wa-task-configuration back into add-roles script.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
