### PR TITLE
CIV-8885 - Assign the claim to new 'DEFENDANT' role.

### DIFF
--- a/bin/add-roles.sh
+++ b/bin/add-roles.sh
@@ -29,7 +29,7 @@ done
 
 accessprofiles=("judge-profile" "basic-access" "ga-basic-access" "legal-adviser" "GS_profile" "caseworker-ras-validation" "full-access" "admin-access"
 "civil-administrator-basic" "civil-administrator-standard" "caseworker-wa-task-configuration" "hearing-schedule-access" "APP-SOL-UNSPEC-PROFILE" "APP-SOL-SPEC-PROFILE" "RES-SOL-ONE-UNSPEC-PROFILE"
-"RES-SOL-ONE-SPEC-PROFILE" "RES-SOL-TWO-UNSPEC-PROFILE" "RES-SOL-TWO-SPEC-PROFILE" "payment-access" "caseflags-admin" "caseflags-viewer" "hearing-manager" "hearing-viewer")
+"RES-SOL-ONE-SPEC-PROFILE" "RES-SOL-TWO-UNSPEC-PROFILE" "RES-SOL-TWO-SPEC-PROFILE" "payment-access" "caseflags-admin" "caseflags-viewer" "hearing-manager" "hearing-viewer" "CLAIMANT" "DEFENDANT")
 
 for accessprofile in "${accessprofiles[@]}"
 do

--- a/bin/users.json
+++ b/bin/users.json
@@ -26,7 +26,7 @@
   {"email": "judge-dredd-01@example.com", "roles": "caseworker,caseworker-civil", "lastName": "standard"},
   {"email": "task-supervisor-civil-01@example.com", ",roles": "caseworker,caseworker-civil", "lastName": "standard"},
   {"email": "case-allocator-civil-01@example.com", "roles": "caseworker,caseworker-civil", "lastName": "standard"},
-  {"email": "jane.smith@gmail.com", "roles": "citizen,caseworker,caseworker-civil,caseworker-civil-solicitor,pui-caa,pui-case-manager,pui-organisation-manager,pui-user-manager,payments", "lastName": "Smith"},
+  {"email": "jane.smith@gmail.com", "roles": "citizen", "lastName": "Smith"},
   {"email": "tribunal-caseworker-01@example.com", "roles": "caseworker,caseworker-civil", "lastName": "tribunal-caseworker"},
   {"email": "hearing-centre-admin-01@example.com", "roles": "caseworker,caseworker-civil", "lastName": "Admin"},
   {"email": "ga_hearing_centre_admin_nw@justice.gov.uk", "roles": "caseworker,caseworker-civil", "lastName": "Admin"},


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-8885


### Change description ###
When Claim is assigned to  new Role 'DEFENDANT' then when login as a Citizen user you can see the assigned claim on the dash board.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
