### PR TITLE
Add citizen role to CCD

### DIFF
--- a/bin/add-roles.sh
+++ b/bin/add-roles.sh
@@ -20,6 +20,8 @@ ${dir}/utils/ccd-add-role.sh "caseworker-approver"
 ${dir}/utils/idam-add-role.sh "prd-aac-system"
 ${dir}/utils/ccd-add-role.sh "prd-aac-system"
 
+${dir}/utils/ccd-add-role.sh "citizen"
+
 roles=("solicitor" "systemupdate" "admin" "staff" "judge")
 for role in "${roles[@]}"
 do


### PR DESCRIPTION
### Change description ###

This is required for the new citizen-profile as the access profile for citizen-profile is built by pulling the entries from the role table corresponding to the idam role.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
