### PR TITLE
Add support for host callbacks on Linux systems

### DIFF
--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -115,6 +115,8 @@ services:
         condition: service_started
     networks:
       - ccd-network
+    extra_hosts:
+      - "docker.for.mac.localhost:host-gateway"
 
   am-role-assignment-service:
     image: "${AM_ROLE_ASSIGNMENT_SERVICE_USE_LOCAL-hmctspublic.azurecr.io/}am/role-assignment-service:${AM_ROLE_ASSIGNMENT_SERVICE_TAG:-latest}"

--- a/compose/xui.yml
+++ b/compose/xui.yml
@@ -60,7 +60,8 @@ services:
         condition: service_started
     networks:
       - ccd-network
-
+    extra_hosts:
+      - "docker.for.mac.localhost:host-gateway"
 networks:
   ccd-network:
     external: true


### PR DESCRIPTION
This will allow Linux based systems to use the `docker.for.mac.localhost` domain to call the host machine (as it does on Macs).