### PR TITLE
CIV-13860 Updated location refdata mocks with external short name

### DIFF
--- a/mocks/wiremock/__files/lrd/ccmccLocation.json
+++ b/mocks/wiremock/__files/lrd/ccmccLocation.json
@@ -35,6 +35,7 @@
     "mrd_building_location_id": "ABC-DEF-240",
     "mrd_venue_id": "ABC-PQR-0812",
     "service_url": "",
-    "fact_url": ""
+    "fact_url": "",
+    "external_short_name": "Randon"
   }
 ]

--- a/mocks/wiremock/__files/lrd/courtLocationsResponse.json
+++ b/mocks/wiremock/__files/lrd/courtLocationsResponse.json
@@ -35,6 +35,7 @@
     "mrd_building_location_id": "",
     "mrd_venue_id": "",
     "service_url": "",
-    "fact_url": ""
+    "fact_url": "",
+    "external_short_name": "Barnet"
   }
 ]

--- a/mocks/wiremock/__files/lrd/hearingLocationsResponse.json
+++ b/mocks/wiremock/__files/lrd/hearingLocationsResponse.json
@@ -73,7 +73,8 @@
     "mrd_building_location_id": "",
     "mrd_venue_id": "",
     "service_url": "",
-    "fact_url": ""
+    "fact_url": "",
+    "external_short_name": "Barnet"
   },
   {
     "court_venue_id": "2222",
@@ -111,7 +112,8 @@
     "mrd_building_location_id": "",
     "mrd_venue_id": "",
     "service_url": "",
-    "fact_url": ""
+    "fact_url": "",
+    "external_short_name": "High Wycombe"
   },
   {
     "court_venue_id": "3333",
@@ -149,6 +151,7 @@
     "mrd_building_location_id": "",
     "mrd_venue_id": "",
     "service_url": "",
-    "fact_url": ""
+    "fact_url": "",
+    "external_short_name": "Central London"
   }
 ]


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-13860

- Updated location refdata mocks to include external short name field


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
